### PR TITLE
noop farmhash

### DIFF
--- a/azureLogIngestion/adapter/utils/resource.test.ts
+++ b/azureLogIngestion/adapter/utils/resource.test.ts
@@ -10,7 +10,7 @@ describe("hash", () => {
                 // /subscriptions/{subscription}/resourceGroups/{resourceGroup}/{provider}/{resourceType}/{resourceName}
                 "/subscriptions/62767007-2c55-4c76-926e-e8482f4e7f25/resourceGroups/test-group/providers/Microsoft.Web/sites/test-function",
             ),
-        ).toBe("MTIzNDU2fElORlJBfEFaVVJFRlVOQ1RJT05BUFB8MTE3MjcxOTQ5MTAyOTQ5MTc0MjM")
+        ).toBe("MTIzNDU2fElORlJBfEFaVVJFRlVOQ1RJT05BUFB8")
     })
 })
 

--- a/azureLogIngestion/adapter/utils/resource.ts
+++ b/azureLogIngestion/adapter/utils/resource.ts
@@ -1,5 +1,6 @@
-import { hash64 } from "farmhash"
-
+// import { hash64 } from "farmhash"
+// TODO: replace with platform-independent hashing, or update build pipeline for farmhash
+const hash64 = (input: Buffer) => ""
 const urlSafeChars = { "+": "-", "/": "_", "=": "" }
 
 /**

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "@newrelic/telemetry-sdk": "^0.4.2",
-    "farmhash": "^3.2.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   }


### PR DESCRIPTION
Removing farmhash for now--our build pipeline builds on ubuntu and ships (potentially) to Windows

Signed-off-by: mrickard <maurice@mauricerickard.com>