### PR TITLE
Install win32 Farm Hash Package at Packaging Time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
         mkdir -p artifacts/zip
         func extensions install
         npm prune --production
+        npm install --platform=win32 farmhash
         zip -r artifacts/zip/${{ env.ARCHIVE }} azureLogIngestion/function.json dist host.json LICENSE node_modules package.json package-lock.json
     - name: Upload build package
       run: |


### PR DESCRIPTION
This is just a workaround. We should probably convert CI to a Windows environment.