### PR TITLE
fix endtime calculation

### DIFF
--- a/azureLogIngestion/opentelemetry/__snapshots__/index.test.ts.snap
+++ b/azureLogIngestion/opentelemetry/__snapshots__/index.test.ts.snap
@@ -27,8 +27,8 @@ Array [
     },
     "duration": undefined,
     "endTime": Array [
-      NaN,
-      NaN,
+      1620155556,
+      184999943,
     ],
     "ended": undefined,
     "events": Array [],
@@ -81,8 +81,8 @@ Array [
     },
     "duration": undefined,
     "endTime": Array [
-      NaN,
-      NaN,
+      1620155556,
+      184999943,
     ],
     "ended": undefined,
     "events": Array [],
@@ -157,8 +157,8 @@ Array [
     },
     "duration": undefined,
     "endTime": Array [
-      NaN,
-      NaN,
+      1620233096,
+      802000046,
     ],
     "ended": undefined,
     "events": Array [],
@@ -226,8 +226,8 @@ Array [
     },
     "duration": undefined,
     "endTime": Array [
-      NaN,
-      NaN,
+      1620233096,
+      802000046,
     ],
     "ended": undefined,
     "events": Array [

--- a/azureLogIngestion/opentelemetry/processors/spans.ts
+++ b/azureLogIngestion/opentelemetry/processors/spans.ts
@@ -248,10 +248,10 @@ export default class SpanProcessor {
 
         // TODO: We need to reset id and parent id here
 
-        span.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs, context))
+        span.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs))
 
         if (parentSpan) {
-            parentSpan.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs, context))
+            parentSpan.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs))
             const logParentSpan = loggableSpan(parentSpan)
             const pSpanRecord = process.env["otelJestTests"]
                 ? logParentSpan

--- a/azureLogIngestion/opentelemetry/processors/spans.ts
+++ b/azureLogIngestion/opentelemetry/processors/spans.ts
@@ -248,10 +248,10 @@ export default class SpanProcessor {
 
         // TODO: We need to reset id and parent id here
 
-        span.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs))
+        span.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs, context))
 
         if (parentSpan) {
-            parentSpan.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs))
+            parentSpan.end(endTimeFromDuration(appSpan.timestamp, appSpan.durationMs, context))
             const logParentSpan = loggableSpan(parentSpan)
             const pSpanRecord = process.env["otelJestTests"]
                 ? logParentSpan

--- a/azureLogIngestion/utils/time.ts
+++ b/azureLogIngestion/utils/time.ts
@@ -1,23 +1,32 @@
-export const convertToMs = (interval: string): number => {
+import { Context as AzureContext } from "@azure/functions"
+
+export const convertToMs = (interval: string, ctx?: AzureContext): number => {
     const scale = String(interval).match(/[a-zA-Z]+/g)
     const intervalNumber = String(interval).match(/[0-9.]+/g)
     let ms
+    if (!interval) {
+        return 0
+    }
     if (!scale) {
+        // ctx.log("no scale", interval)
         return Number(interval)
     }
     const units = scale[0].toLowerCase()
+    // ctx.log(`UNITS ${units}`, interval, scale[0])
     if (units === "ms") {
         ms = Number(intervalNumber[0])
     } else if (units === "s") {
         ms = Number(intervalNumber[0]) * 1000
     } else if (units === "m") {
         ms = Number(intervalNumber[0]) * 1000 * 60
+    } else {
+        return Number(interval)
     }
     return ms
 }
 
-export const endTimeFromDuration = (timestamp: string, duration: string): Date => {
+export const endTimeFromDuration = (timestamp: string, duration: string, ctx?: AzureContext): Date => {
     const dateTime = new Date(timestamp).getTime()
-    const elapsed = convertToMs(duration)
+    const elapsed = convertToMs(duration, ctx)
     return new Date(dateTime + elapsed)
 }

--- a/azureLogIngestion/utils/time.ts
+++ b/azureLogIngestion/utils/time.ts
@@ -1,6 +1,8 @@
 import { Context as AzureContext } from "@azure/functions"
+import { timeInputToHrTime } from "@opentelemetry/core"
+import { HrTime } from "@opentelemetry/api"
 
-export const convertToMs = (interval: string, ctx?: AzureContext): number => {
+export const convertToMs = (interval: string): number => {
     const scale = String(interval).match(/[a-zA-Z]+/g)
     const intervalNumber = String(interval).match(/[0-9.]+/g)
     let ms
@@ -8,11 +10,9 @@ export const convertToMs = (interval: string, ctx?: AzureContext): number => {
         return 0
     }
     if (!scale) {
-        // ctx.log("no scale", interval)
         return Number(interval)
     }
     const units = scale[0].toLowerCase()
-    // ctx.log(`UNITS ${units}`, interval, scale[0])
     if (units === "ms") {
         ms = Number(intervalNumber[0])
     } else if (units === "s") {
@@ -25,8 +25,9 @@ export const convertToMs = (interval: string, ctx?: AzureContext): number => {
     return ms
 }
 
-export const endTimeFromDuration = (timestamp: string, duration: string, ctx?: AzureContext): Date => {
+export const endTimeFromDuration = (timestamp: string, duration: string): HrTime => {
     const dateTime = new Date(timestamp).getTime()
-    const elapsed = convertToMs(duration, ctx)
-    return new Date(dateTime + elapsed)
+    const elapsed = convertToMs(duration)
+    const endTime = new Date(dateTime + elapsed)
+    return timeInputToHrTime(endTime)
 }


### PR DESCRIPTION
This change leverages the OTJS project's `timeInputToHrTime` to give more predictable timestamps in spans.